### PR TITLE
add abbreviation as external id

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,9 +1,11 @@
 type BookReference {
   id: ID!
+  abbreviation: String! @search @id
   name: String! @search(by: [term, exact])
   number: Int! @search 
   chapterReferences: [ChapterReference!] @hasInverse(field: bookReference)
 }
+
 
 type ChapterReference {
   id: ID!


### PR DESCRIPTION
makes getBookReference work instead of having to do filtered queries to find a BookReference if you don't have the uid