### PR TITLE
Add back and machine translation support to schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -25,9 +25,12 @@ type BibleVersion {
   name: String! @search(by: [term, exact])
   language: ISOLanguage! 
   script: ISOScript!
-  abbreviation: String @search
+  abbreviation: String @search @id
   rights: String @search(by: [term, exact])
   revisions: [BibleRevision] @hasInverse(field: bibleVersion)
+  forwardTranslation: BibleRevision @hasInverse(field: backTranslation)
+  backTranslation: BibleRevision @hasInverse(field: forwardTranslation)
+  machineTranslation: Boolean
 }
 
 type ISOLanguage {

--- a/schema.graphql
+++ b/schema.graphql
@@ -51,6 +51,7 @@ type BibleRevision {
   id: ID!
   date: DateTime! @search
   bibleVersion: BibleVersion!
+  published: Boolean
   verseTexts: [VerseText!] @hasInverse(field: bibleRevision)
   assessments: [Assessment] @hasInverse(field: bibleRevision)
 }


### PR DESCRIPTION
backTranslation, forwardTranslation and machineTranslation allow for filtering of translations for ML to include only natural language translations. Also added @id to abbreviations based on Gary's suggestion.