### PR TITLE
Update schema.graphql

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -107,6 +107,7 @@ type AssessmentMetric {
   assessmentDetail: AssessmentDetail!
   flag: Boolean @search
   number: Float @search
+  tag: String @search
 }
 
 enum AnnotationType {

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,9 @@
-type BookReference {
+interface Reference {
+  id: ID!
+  number: Int! @search
+}
+
+type BookReference implements Reference{
   id: ID!
   abbreviation: String! @search @id
   name: String! @search(by: [term, exact])
@@ -8,14 +13,14 @@ type BookReference {
 }
 
 
-type ChapterReference {
+type ChapterReference implements Reference{
   id: ID!
   number: Int! @search
   bookReference: BookReference!
   verseReferences: [VerseReference!] @hasInverse(field: chapterReference)
 }
 
-type VerseReference {
+type VerseReference implements Reference{
   id: ID!
   fullVerseId: String! @search @id
   number: Int! @search
@@ -74,56 +79,63 @@ type VerseText {
   assessmentDetails: [AssessmentDetail]
 }
 
-enum AssessmentType {
+enum TextAnnotationType {
   SemanticSimilarity
   QAComprehensibility
   SubwordsPerSentence
+  VersePart
+  PartOfSpeech
+  NamedEntity
+}
+
+enum ReferenceAnnotationType {
+  SemanticDomain
+  KeyTerm
 }
 
 type Assessment {
   id: ID!
-  type: AssessmentType! @search(by: [exact])
+  type: TextAnnotationType! @search(by: [exact])
   bibleRevision: BibleRevision!
   reference: BibleRevision
   date: DateTime! @search
-  details: [AssessmentDetail!] @hasInverse(field: assessment)
+  details: [Annotation!] @hasInverse(field: assessment)
 }
 
-type AssessmentDetail {
+interface Annotation {
   id: ID!
-  assessment: Assessment!
-  assessmentMetrics: [AssessmentMetric!] @hasInverse(field: assessmentDetail)
+  flag: Boolean @search
+  number: Float @search
+  tag: String @search
+  parent: [Annotation] @hasInverse(field: children)
+  children: [Annotation] @hasInverse(field: parent)
+}
+
+type TextAnnotation implements Annotation {
+  id: ID!
   verseTexts: [VerseText!]
   startPosition: Int
   endPosition: Int
   refVerseTexts: [VerseText]
   refStartPosition: Int
   refEndPosition: Int
-  annotations: [Annotation] @hasInverse(field: assessmentDetail)
-}
-
-type AssessmentMetric {
-  id: ID!
-  assessmentDetail: AssessmentDetail!
   flag: Boolean @search
   number: Float @search
   tag: String @search
+  parent: [Annotation] @hasInverse(field: children)
+  children: [Annotation] @hasInverse(field: parent)
+  assessment: [Assessment] @hasInverse(field: details)
+  type: TextAnnotationType!
 }
 
-enum AnnotationType {
-  SubAssessment
-  VersePart
-  PartOfSpeech
-}
-
-type Annotation {
+type ReferenceAnnotation implements Annotation {
   id: ID!
-  verseTexts: [VerseText!]
-  startPosition: Int
-  endPosition: Int
-  assessmentDetail: [AssessmentDetail] @hasInverse(field: annotations)
+  reference: [Reference!]
   flag: Boolean @search
   number: Float @search
   tag: String @search
+  parent: [Annotation] @hasInverse(field: children)
+  children: [Annotation] @hasInverse(field: parent)
+  type: ReferenceAnnotationType!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -17,6 +17,7 @@ type ChapterReference {
 
 type VerseReference {
   id: ID!
+  fullVerseId: String! @search @id
   number: Int! @search
   chapterReference: ChapterReference!
 }
@@ -92,7 +93,13 @@ type AssessmentDetail {
   id: ID!
   assessment: Assessment!
   assessmentMetrics: [AssessmentMetric!] @hasInverse(field: assessmentDetail)
-  verseTexts: [VerseText]
+  verseTexts: [VerseText!]
+  startPosition: Int
+  endPosition: Int
+  refVerseTexts: [VerseText]
+  refStartPosition: Int
+  refEndPosition: Int
+  annotations: [Annotation] @hasInverse(field: assessmentDetail)
 }
 
 type AssessmentMetric {
@@ -101,3 +108,21 @@ type AssessmentMetric {
   flag: Boolean @search
   number: Float @search
 }
+
+enum AnnotationType {
+  SubAssessment
+  VersePart
+  PartOfSpeech
+}
+
+type Annotation {
+  id: ID!
+  verseTexts: [VerseText!]
+  startPosition: Int
+  endPosition: Int
+  assessmentDetail: [AssessmentDetail] @hasInverse(field: annotations)
+  flag: Boolean @search
+  number: Float @search
+  tag: String @search
+}
+

--- a/schema.graphql
+++ b/schema.graphql
@@ -107,8 +107,6 @@ interface Annotation {
   flag: Boolean @search
   number: Float @search
   tag: String @search
-  parent: [Annotation] @hasInverse(field: children)
-  children: [Annotation] @hasInverse(field: parent)
 }
 
 type TextAnnotation implements Annotation {
@@ -122,8 +120,6 @@ type TextAnnotation implements Annotation {
   flag: Boolean @search
   number: Float @search
   tag: String @search
-  parent: [Annotation] @hasInverse(field: children)
-  children: [Annotation] @hasInverse(field: parent)
   assessment: [Assessment] @hasInverse(field: details)
   type: TextAnnotationType!
 }
@@ -134,8 +130,6 @@ type ReferenceAnnotation implements Annotation {
   flag: Boolean @search
   number: Float @search
   tag: String @search
-  parent: [Annotation] @hasInverse(field: children)
-  children: [Annotation] @hasInverse(field: parent)
   type: ReferenceAnnotationType!
 }
 


### PR DESCRIPTION
prepare for storing annotations for sub assessments or supplementary metadata. Ideally bible-graph stores both the data and metadata necessary for assessments and the full output including assessments and annotations. Combined with a model, hardware, and a description of how the assessment works, it should allow full-reproducibility.